### PR TITLE
Make sure case matches actual filename

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "description":
     "Mask input component. Allow to input formatted values with fixed length or apply custom formatting function, to format values with any length",
-  "main": "./lib/maskInput.js",
+  "main": "./lib/MaskInput.js",
   "scripts": {
     "build": "babel ./src --out-dir ./lib",
     "size": "size-limit",


### PR DESCRIPTION
Usage of this module fails on case-sensitive file systems because of a mismatch between the reference in `package.json` and the actual main file itself.

I’ve updated `package.json` to use the same case as the file in lib. `MaskInput.js` not `maskInput.js`